### PR TITLE
feat(cost-monitoring): add absolute cost threshold to anomaly detecti…

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -133,11 +133,22 @@ Resources:
         - Address: !Ref SlackSnsArn
           Type: "SNS"
       ThresholdExpression: '{
-        "Dimensions": {
-          "Key": "ANOMALY_TOTAL_IMPACT_PERCENTAGE",
-          "MatchOptions": [ "GREATER_THAN_OR_EQUAL" ],
-          "Values": [ "70" ]
-        }
+        "And": [
+          {
+            "Dimensions": {
+              "Key": "ANOMALY_TOTAL_IMPACT_PERCENTAGE",
+              "MatchOptions": [ "GREATER_THAN_OR_EQUAL" ],
+              "Values": [ "70" ]
+            }
+          },
+          {
+            "Dimensions": {
+              "Key": "ANOMALY_TOTAL_IMPACT_ABSOLUTE",
+              "MatchOptions": [ "GREATER_THAN_OR_EQUAL" ],
+              "Values": [ "50" ]
+            }
+          }
+        ]
       }'
       SubscriptionName: "Cost Anomaly Subscription"
 


### PR DESCRIPTION
…on #NP-50205

The change updates the CostAnomalyMonitor to require both:
- 70% impact percentage threshold (existing)
- $50 absolute impact threshold (new)

This prevents alerts for small anomalies that meet the percentage threshold but have minimal absolute cost impact.