### PR TITLE
feat(dashboard): documentation links, alarm filter, lambda split and layout #NP-51227

### DIFF
--- a/dashboard/src/main/java/no/sikt/nva/monitoring/LambdaMetric.java
+++ b/dashboard/src/main/java/no/sikt/nva/monitoring/LambdaMetric.java
@@ -1,6 +1,6 @@
 package no.sikt.nva.monitoring;
 
-public record LambdaMetric(String stat, String region) {
+public record LambdaMetric(String stat, String region, Boolean visible) {
 
     public static Builder builder() {
         return new Builder();
@@ -10,6 +10,7 @@ public record LambdaMetric(String stat, String region) {
 
         private String stat;
         private String region;
+        private Boolean visible;
 
         private Builder() {
         }
@@ -24,8 +25,13 @@ public record LambdaMetric(String stat, String region) {
             return this;
         }
 
+        public Builder withVisible(Boolean visible) {
+            this.visible = visible;
+            return this;
+        }
+
         public LambdaMetric build() {
-            return new LambdaMetric(stat, region);
+            return new LambdaMetric(stat, region, visible);
         }
     }
 }

--- a/dashboard/src/main/java/no/sikt/nva/monitoring/LambdaWidget.java
+++ b/dashboard/src/main/java/no/sikt/nva/monitoring/LambdaWidget.java
@@ -2,6 +2,8 @@ package no.sikt.nva.monitoring;
 
 import java.util.List;
 import no.sikt.nva.monitoring.model.CloudWatchWidget;
+import no.sikt.nva.monitoring.model.LambdaGraphProperties;
+import no.sikt.nva.monitoring.model.MetricSearchExpression;
 import software.amazon.awssdk.regions.Region;
 
 public final class LambdaWidget {
@@ -15,17 +17,28 @@ public final class LambdaWidget {
     public static final String ASYNC_EVENT_AGE = "AsyncEventAge";
     public static final String LAMBDA_METRICS_TITLE = "Lambda metrics - last 5 minutes";
     public static final String SINGLE_VALUE = "singleValue";
+    public static final String TIME_SERIES = "timeSeries";
     public static final String SUM_STAT = "Sum";
+    public static final String MAXIMUM_STAT = "Maximum";
     public static final int PERIOD_5_MINUTES = 300;
     public static final String METRIC = "metric";
-    public static final String MAXIMUM_STAT = "Maximum";
+    public static final String SEARCH_EXPRESSION_TEMPLATE =
+        "SEARCH('{AWS/Lambda,FunctionName} MetricName=\"%s\"', '%s', %d)";
+    public static final String FUNCTION_NAME_LABEL = "${PROP('Dim.FunctionName')}";
+    private static final int CONCURRENCY_WIDGET_HEIGHT = 4;
+    private static final int CONCURRENCY_WIDGET_WIDTH = 10;
+    private static final int CONCURRENCY_WIDGET_X = 0;
+    private static final int CONCURRENCY_WIDGET_Y = 4;
+    private static final int GRAPH_HEIGHT = 6;
+    private static final int GRAPH_WIDTH = 6;
+    private static final int GRAPH_ROW_Y = 30;
 
     private LambdaWidget() {
     }
 
-    public static CloudWatchWidget<LambdaProperties> create() {
+    public static CloudWatchWidget<LambdaProperties> createConcurrencyWidget() {
         var lambdaProperties = LambdaProperties.builder()
-                                   .withMetrics(getAwsLambdaMetricEntry())
+                                   .withMetrics(getConcurrencyMetricEntries())
                                    .withTitle(LAMBDA_METRICS_TITLE)
                                    .withView(SINGLE_VALUE)
                                    .withRegion(Region.EU_WEST_1.toString())
@@ -37,17 +50,43 @@ public final class LambdaWidget {
                                    .withLiveData(true)
                                    .withSingleValueFullPrecision(true)
                                    .build();
-        return new CloudWatchWidget<>(METRIC, lambdaProperties, 4, 24, 5, 0);
+        return new CloudWatchWidget<>(METRIC, lambdaProperties, CONCURRENCY_WIDGET_HEIGHT, CONCURRENCY_WIDGET_WIDTH,
+                                      CONCURRENCY_WIDGET_X, CONCURRENCY_WIDGET_Y);
     }
 
-    private static List<List<Object>> getAwsLambdaMetricEntry() {
+    public static List<CloudWatchWidget<LambdaGraphProperties>> createPerFunctionGraphs() {
+        return List.of(createPerFunctionGraph(ERRORS, SUM_STAT, 0),
+                       createPerFunctionGraph(THROTTLES, SUM_STAT, 1),
+                       createPerFunctionGraph(INVOCATIONS, SUM_STAT, 2),
+                       createPerFunctionGraph(ASYNC_EVENT_AGE, MAXIMUM_STAT, 3));
+    }
+
+    private static CloudWatchWidget<LambdaGraphProperties> createPerFunctionGraph(String metricName, String stat,
+                                                                                  int columnIndex) {
+        var properties = new LambdaGraphProperties(searchExpressionMetrics(metricName, stat),
+                                                   metricName,
+                                                   TIME_SERIES,
+                                                   Region.EU_WEST_1.toString(),
+                                                   stat,
+                                                   PERIOD_5_MINUTES,
+                                                   true);
+        return new CloudWatchWidget<>(METRIC, properties, GRAPH_HEIGHT, GRAPH_WIDTH, columnIndex * GRAPH_WIDTH,
+                                      GRAPH_ROW_Y);
+    }
+
+    private static List<List<Object>> searchExpressionMetrics(String metricName, String stat) {
+        var expression = SEARCH_EXPRESSION_TEMPLATE.formatted(metricName, stat, PERIOD_5_MINUTES);
+        return List.of(List.of(new MetricSearchExpression(expression, FUNCTION_NAME_LABEL)));
+    }
+
+    private static List<List<Object>> getConcurrencyMetricEntries() {
         return List.of(
-            createAwsLambdaMetricEntry(ERRORS, lambdaMetricWithRegion()),
-            createAwsLambdaMetricEntry(THROTTLES, lambdaMetricWithRegion()),
-            createAwsLambdaMetricEntry(INVOCATIONS, lambdaMetricWithRegion()),
-            createAwsLambdaMetricEntry(CONCURRENT_EXECUTIONS, lambdaMetricWithRegionAndMaxStat()),
-            createAwsLambdaMetricEntry(CLAIMED_ACCOUNT_CONCURRENCY, lambdaMetricWithRegionAndMaxStat()),
-            createAwsLambdaMetricEntry(ASYNC_EVENT_AGE, lambdaMetricWithRegionAndMaxStat())
+            createAwsLambdaMetricEntry(ERRORS, hiddenMetric()),
+            createAwsLambdaMetricEntry(THROTTLES, hiddenMetric()),
+            createAwsLambdaMetricEntry(INVOCATIONS, hiddenMetric()),
+            createAwsLambdaMetricEntry(CONCURRENT_EXECUTIONS, visibleMaxStatMetric()),
+            createAwsLambdaMetricEntry(CLAIMED_ACCOUNT_CONCURRENCY, visibleMaxStatMetric()),
+            createAwsLambdaMetricEntry(ASYNC_EVENT_AGE, hiddenMaxStatMetric())
         );
     }
 
@@ -55,11 +94,19 @@ public final class LambdaWidget {
         return List.of(AWS_LAMBDA, type, lambdaMetric);
     }
 
-    private static LambdaMetric lambdaMetricWithRegion() {
-        return LambdaMetric.builder().withRegion(Region.EU_WEST_1.toString()).build();
+    private static LambdaMetric hiddenMetric() {
+        return LambdaMetric.builder().withRegion(Region.EU_WEST_1.toString()).withVisible(false).build();
     }
 
-    private static LambdaMetric lambdaMetricWithRegionAndMaxStat() {
+    private static LambdaMetric hiddenMaxStatMetric() {
+        return LambdaMetric.builder()
+                   .withRegion(Region.EU_WEST_1.toString())
+                   .withStat(MAXIMUM_STAT)
+                   .withVisible(false)
+                   .build();
+    }
+
+    private static LambdaMetric visibleMaxStatMetric() {
         return LambdaMetric.builder().withRegion(Region.EU_WEST_1.toString()).withStat(MAXIMUM_STAT).build();
     }
 }

--- a/dashboard/src/main/java/no/sikt/nva/monitoring/LambdaWidget.java
+++ b/dashboard/src/main/java/no/sikt/nva/monitoring/LambdaWidget.java
@@ -25,13 +25,13 @@ public final class LambdaWidget {
     public static final String SEARCH_EXPRESSION_TEMPLATE =
         "SEARCH('{AWS/Lambda,FunctionName} MetricName=\"%s\"', '%s', %d)";
     public static final String FUNCTION_NAME_LABEL = "${PROP('Dim.FunctionName')}";
-    private static final int CONCURRENCY_WIDGET_HEIGHT = 4;
-    private static final int CONCURRENCY_WIDGET_WIDTH = 10;
-    private static final int CONCURRENCY_WIDGET_X = 0;
-    private static final int CONCURRENCY_WIDGET_Y = 4;
+    private static final int CONCURRENCY_WIDGET_HEIGHT = 3;
+    private static final int CONCURRENCY_WIDGET_WIDTH = 12;
+    private static final int CONCURRENCY_WIDGET_X = 6;
+    private static final int CONCURRENCY_WIDGET_Y = 0;
     private static final int GRAPH_HEIGHT = 6;
     private static final int GRAPH_WIDTH = 6;
-    private static final int GRAPH_ROW_Y = 30;
+    private static final int GRAPH_ROW_Y = 3;
 
     private LambdaWidget() {
     }

--- a/dashboard/src/main/java/no/sikt/nva/monitoring/UpdateDashboardHandler.java
+++ b/dashboard/src/main/java/no/sikt/nva/monitoring/UpdateDashboardHandler.java
@@ -3,8 +3,8 @@ package no.sikt.nva.monitoring;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.CloudFormationCustomResourceEvent;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 import no.sikt.nva.monitoring.model.CloudWatchWidget;
 import no.sikt.nva.monitoring.model.DashboardBody;
 import no.sikt.nva.monitoring.model.factory.AlarmWidgetFactory;
@@ -29,6 +29,8 @@ public class UpdateDashboardHandler implements RequestHandler<CloudFormationCust
     public static final String API_REQUEST_COUNT_WIDGET_NAME = "Count";
     public static final String API_ERRORS_4XX_WIDGET_NAME = "4XXError";
     public static final String API_ERRORS_5XX_WIDGET_NAME = "5XXError";
+    public static final int LOG_5XX_X_COORDINATE = 0;
+    public static final int LOG_4XX_X_COORDINATE = 12;
     private final CloudWatchClient cloudWatchClient;
     private final CloudWatchLogsClient cloudWatchLogsClient;
     private final String dashboardName;
@@ -72,19 +74,18 @@ public class UpdateDashboardHandler implements RequestHandler<CloudFormationCust
         var apiGatewayCountWidget = apigatewayFactory.creatCloudWatchWidget(2, API_REQUEST_COUNT_WIDGET_NAME);
         var logWidgetFactory = new LogWidgetFactory(cloudWatchLogsClient);
         var log5xxWidget = logWidgetFactory.createLogWidgetForApiGatewayLogs(
-            API_GATEWAY_5XX_ERROR_LOG, FILTER_FOR_5XX_ERRORS);
+            API_GATEWAY_5XX_ERROR_LOG, FILTER_FOR_5XX_ERRORS, LOG_5XX_X_COORDINATE);
         var log4xxWidget = logWidgetFactory.createLogWidgetForApiGatewayLogs(
-            API_GATEWAY_4XX_ERROR_LOG, FILTER_FOR_4XX_ERRORS);
+            API_GATEWAY_4XX_ERROR_LOG, FILTER_FOR_4XX_ERRORS, LOG_4XX_X_COORDINATE);
         var lambdaConcurrencyWidget = LambdaWidget.createConcurrencyWidget();
-        var widgets = new ArrayList<CloudWatchWidget>(List.of(documentationLinksWidget,
-                                                              alarmWidget,
-                                                              lambdaConcurrencyWidget,
-                                                              apiGateway5xxWidget,
-                                                              apiGateway4xxWidget,
-                                                              apiGatewayCountWidget,
-                                                              log5xxWidget,
-                                                              log4xxWidget));
-        widgets.addAll(LambdaWidget.createPerFunctionGraphs());
-        return widgets;
+        var staticWidgets = Stream.<CloudWatchWidget>of(documentationLinksWidget,
+                                                        alarmWidget,
+                                                        lambdaConcurrencyWidget,
+                                                        apiGateway5xxWidget,
+                                                        apiGateway4xxWidget,
+                                                        apiGatewayCountWidget,
+                                                        log5xxWidget,
+                                                        log4xxWidget);
+        return Stream.concat(staticWidgets, LambdaWidget.createPerFunctionGraphs().stream()).toList();
     }
 }

--- a/dashboard/src/main/java/no/sikt/nva/monitoring/UpdateDashboardHandler.java
+++ b/dashboard/src/main/java/no/sikt/nva/monitoring/UpdateDashboardHandler.java
@@ -3,11 +3,13 @@ package no.sikt.nva.monitoring;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.CloudFormationCustomResourceEvent;
+import java.util.ArrayList;
 import java.util.List;
 import no.sikt.nva.monitoring.model.CloudWatchWidget;
 import no.sikt.nva.monitoring.model.DashboardBody;
 import no.sikt.nva.monitoring.model.factory.AlarmWidgetFactory;
 import no.sikt.nva.monitoring.model.factory.ApiGatewayWidgetFactory;
+import no.sikt.nva.monitoring.model.factory.DocumentationLinksWidget;
 import no.sikt.nva.monitoring.model.factory.LogWidgetFactory;
 import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
@@ -62,6 +64,7 @@ public class UpdateDashboardHandler implements RequestHandler<CloudFormationCust
     }
 
     private List<CloudWatchWidget> createWidgets() {
+        var documentationLinksWidget = DocumentationLinksWidget.create();
         var alarmWidget = new AlarmWidgetFactory(cloudWatchClient).creatCloudWatchWidget();
         var apigatewayFactory = new ApiGatewayWidgetFactory(apiGatewayClient);
         var apiGateway5xxWidget = apigatewayFactory.creatCloudWatchWidget(0, API_ERRORS_5XX_WIDGET_NAME);
@@ -72,13 +75,16 @@ public class UpdateDashboardHandler implements RequestHandler<CloudFormationCust
             API_GATEWAY_5XX_ERROR_LOG, FILTER_FOR_5XX_ERRORS);
         var log4xxWidget = logWidgetFactory.createLogWidgetForApiGatewayLogs(
             API_GATEWAY_4XX_ERROR_LOG, FILTER_FOR_4XX_ERRORS);
-        var lambdaWidget = LambdaWidget.create();
-        return List.of(alarmWidget,
-                       lambdaWidget,
-                       apiGateway5xxWidget,
-                       apiGateway4xxWidget,
-                       apiGatewayCountWidget,
-                       log5xxWidget,
-                       log4xxWidget);
+        var lambdaConcurrencyWidget = LambdaWidget.createConcurrencyWidget();
+        var widgets = new ArrayList<CloudWatchWidget>(List.of(documentationLinksWidget,
+                                                              alarmWidget,
+                                                              lambdaConcurrencyWidget,
+                                                              apiGateway5xxWidget,
+                                                              apiGateway4xxWidget,
+                                                              apiGatewayCountWidget,
+                                                              log5xxWidget,
+                                                              log4xxWidget));
+        widgets.addAll(LambdaWidget.createPerFunctionGraphs());
+        return widgets;
     }
 }

--- a/dashboard/src/main/java/no/sikt/nva/monitoring/model/AlarmProperties.java
+++ b/dashboard/src/main/java/no/sikt/nva/monitoring/model/AlarmProperties.java
@@ -3,7 +3,7 @@ package no.sikt.nva.monitoring.model;
 import java.util.List;
 import no.unit.nva.commons.json.JsonSerializable;
 
-public record AlarmProperties(String title, List<String> alarms, String sortBy) implements WidgetProperties,
-                                                                                           JsonSerializable {
+public record AlarmProperties(String title, List<String> alarms, String sortBy, List<String> states)
+    implements WidgetProperties, JsonSerializable {
 
 }

--- a/dashboard/src/main/java/no/sikt/nva/monitoring/model/LambdaGraphProperties.java
+++ b/dashboard/src/main/java/no/sikt/nva/monitoring/model/LambdaGraphProperties.java
@@ -1,0 +1,13 @@
+package no.sikt.nva.monitoring.model;
+
+import java.util.List;
+
+public record LambdaGraphProperties(List<List<Object>> metrics,
+                                    String title,
+                                    String view,
+                                    String region,
+                                    String stat,
+                                    int period,
+                                    boolean liveData) implements WidgetProperties {
+
+}

--- a/dashboard/src/main/java/no/sikt/nva/monitoring/model/MetricSearchExpression.java
+++ b/dashboard/src/main/java/no/sikt/nva/monitoring/model/MetricSearchExpression.java
@@ -1,0 +1,7 @@
+package no.sikt.nva.monitoring.model;
+
+import no.unit.nva.commons.json.JsonSerializable;
+
+public record MetricSearchExpression(String expression, String label) implements JsonSerializable {
+
+}

--- a/dashboard/src/main/java/no/sikt/nva/monitoring/model/TextProperties.java
+++ b/dashboard/src/main/java/no/sikt/nva/monitoring/model/TextProperties.java
@@ -1,0 +1,7 @@
+package no.sikt.nva.monitoring.model;
+
+import no.unit.nva.commons.json.JsonSerializable;
+
+public record TextProperties(String markdown) implements WidgetProperties, JsonSerializable {
+
+}

--- a/dashboard/src/main/java/no/sikt/nva/monitoring/model/factory/AlarmWidgetFactory.java
+++ b/dashboard/src/main/java/no/sikt/nva/monitoring/model/factory/AlarmWidgetFactory.java
@@ -13,8 +13,8 @@ import software.amazon.awssdk.services.cloudwatch.model.MetricAlarm;
 public class AlarmWidgetFactory {
 
     public static final String ALARMS = "alarms";
-    public static final int WIDTH = 24;
-    public static final int HEIGHT = 4;
+    public static final int WIDTH = 6;
+    public static final int HEIGHT = 3;
     public static final int X_COORDINATE = 0;
     public static final int Y_COORDINATE = 0;
     public static final String STATE_UPDATED_TIMESTAMP = "stateUpdatedTimestamp";

--- a/dashboard/src/main/java/no/sikt/nva/monitoring/model/factory/AlarmWidgetFactory.java
+++ b/dashboard/src/main/java/no/sikt/nva/monitoring/model/factory/AlarmWidgetFactory.java
@@ -19,6 +19,7 @@ public class AlarmWidgetFactory {
     public static final int Y_COORDINATE = 0;
     public static final String STATE_UPDATED_TIMESTAMP = "stateUpdatedTimestamp";
     public static final String ALARM = "alarm";
+    public static final String ALARM_STATE = "ALARM";
     private final CloudWatchClient cloudWatchClient;
 
     public AlarmWidgetFactory(CloudWatchClient cloudWatchClient) {
@@ -30,7 +31,7 @@ public class AlarmWidgetFactory {
     }
 
     private AlarmProperties createAlarmProperties() {
-        return new AlarmProperties(ALARMS, retrieveExistingAlarms(), STATE_UPDATED_TIMESTAMP);
+        return new AlarmProperties(ALARMS, retrieveExistingAlarms(), STATE_UPDATED_TIMESTAMP, List.of(ALARM_STATE));
     }
 
     private List<String> retrieveExistingAlarms() {

--- a/dashboard/src/main/java/no/sikt/nva/monitoring/model/factory/ApiGatewayWidgetFactory.java
+++ b/dashboard/src/main/java/no/sikt/nva/monitoring/model/factory/ApiGatewayWidgetFactory.java
@@ -17,7 +17,7 @@ public class ApiGatewayWidgetFactory {
     public static final boolean NOT_STACKED = false;
     public static final int HEIGHT = 9;
     public static final int WIDTH = 8;
-    public static final int Y_COORDINATE = 8;
+    public static final int Y_COORDINATE = 9;
     public static final String AWS_API_GATEWAY = "AWS/ApiGateway";
     public static final String API_NAME = "ApiName";
     private final ApiGatewayClient apiGatewayClient;

--- a/dashboard/src/main/java/no/sikt/nva/monitoring/model/factory/DocumentationLinksWidget.java
+++ b/dashboard/src/main/java/no/sikt/nva/monitoring/model/factory/DocumentationLinksWidget.java
@@ -1,0 +1,29 @@
+package no.sikt.nva.monitoring.model.factory;
+
+import no.sikt.nva.monitoring.model.CloudWatchWidget;
+import no.sikt.nva.monitoring.model.TextProperties;
+
+public final class DocumentationLinksWidget {
+
+    public static final String TEXT = "text";
+    public static final String INSTRUCTIONS_URL =
+        "https://sikt.atlassian.net/wiki/spaces/NVAP/pages/4021749297/Backend+support+rotation";
+    public static final String INCIDENT_RESPONSE_URL =
+        "https://sikt.atlassian.net/wiki/spaces/NVAP/pages/4074700838/Incident+response+routine";
+    public static final String REDRIVE_DLQ_URL =
+        "https://sikt.atlassian.net/wiki/spaces/NVAP/pages/4122181684/Processing+of+messages+on+DLQ";
+    public static final String MARKDOWN =
+        "[Instructions](%s) | [Incident response](%s) | [Redrive DLQ](%s)"
+            .formatted(INSTRUCTIONS_URL, INCIDENT_RESPONSE_URL, REDRIVE_DLQ_URL);
+    public static final int HEIGHT = 1;
+    public static final int WIDTH = 24;
+    public static final int X_COORDINATE = 0;
+    public static final int Y_COORDINATE = 0;
+
+    private DocumentationLinksWidget() {
+    }
+
+    public static CloudWatchWidget<TextProperties> create() {
+        return new CloudWatchWidget<>(TEXT, new TextProperties(MARKDOWN), HEIGHT, WIDTH, X_COORDINATE, Y_COORDINATE);
+    }
+}

--- a/dashboard/src/main/java/no/sikt/nva/monitoring/model/factory/DocumentationLinksWidget.java
+++ b/dashboard/src/main/java/no/sikt/nva/monitoring/model/factory/DocumentationLinksWidget.java
@@ -15,9 +15,9 @@ public final class DocumentationLinksWidget {
     public static final String MARKDOWN =
         "[Instructions](%s) | [Incident response](%s) | [Redrive DLQ](%s)"
             .formatted(INSTRUCTIONS_URL, INCIDENT_RESPONSE_URL, REDRIVE_DLQ_URL);
-    public static final int HEIGHT = 1;
-    public static final int WIDTH = 24;
-    public static final int X_COORDINATE = 0;
+    public static final int HEIGHT = 3;
+    public static final int WIDTH = 6;
+    public static final int X_COORDINATE = 18;
     public static final int Y_COORDINATE = 0;
 
     private DocumentationLinksWidget() {

--- a/dashboard/src/main/java/no/sikt/nva/monitoring/model/factory/LogWidgetFactory.java
+++ b/dashboard/src/main/java/no/sikt/nva/monitoring/model/factory/LogWidgetFactory.java
@@ -22,20 +22,20 @@ public class LogWidgetFactory {
     public static final String DEFAULT_STATS = "stats count() as ErrorCount by httpMethod, path, status";
     public static final String MASTER_PIPELINES = "master-pipelines";
     public static final String API_ACCESS_LOG_GROUP_NAME_PATTERN = "*ApiAccessLogGroup*";
-    public static final int HEIGHT = 6;
-    public static final int WIDTH = 24;
-    public static final int Y = 24;
-    public static final int X = 12;
+    public static final int HEIGHT = 8;
+    public static final int WIDTH = 12;
+    public static final int Y = 18;
     private final CloudWatchLogsClient cloudWatchLogsClient;
 
     public LogWidgetFactory(CloudWatchLogsClient cloudWatchLogsClient) {
         this.cloudWatchLogsClient = cloudWatchLogsClient;
     }
 
-    public CloudWatchWidget<LogProperties> createLogWidgetForApiGatewayLogs(String title, String filter) {
+    public CloudWatchWidget<LogProperties> createLogWidgetForApiGatewayLogs(String title, String filter,
+                                                                            int coordinateX) {
         var logGroups = fetchApiGatewayLogGroups();
         var query = constructQueryForLogGroupsWithFilter(logGroups, filter);
-        return new CloudWatchWidget<>(LOG, constructLogProperties(title, query), HEIGHT, WIDTH, X, Y);
+        return new CloudWatchWidget<>(LOG, constructLogProperties(title, query), HEIGHT, WIDTH, coordinateX, Y);
     }
 
     public List<String> fetchApiGatewayLogGroups() {

--- a/dashboard/src/main/java/no/sikt/nva/monitoring/model/factory/LogWidgetFactory.java
+++ b/dashboard/src/main/java/no/sikt/nva/monitoring/model/factory/LogWidgetFactory.java
@@ -18,8 +18,8 @@ public class LogWidgetFactory {
     public static final String TABLE_VIEW = "table";
     public static final String LIMIT_100 = "limit 100";
     public static final String SORT_TIMESTAMP_DESC = "sort ErrorCount desc";
-    public static final String DEFAULT_FIELDS = "fields httpMethod, path, status, error.message";
-    public static final String DEFAULT_STATS = "stats count() as ErrorCount by httpMethod, path, status, error.message";
+    public static final String DEFAULT_FIELDS = "fields httpMethod, path, status";
+    public static final String DEFAULT_STATS = "stats count() as ErrorCount by httpMethod, path, status";
     public static final String MASTER_PIPELINES = "master-pipelines";
     public static final String API_ACCESS_LOG_GROUP_NAME_PATTERN = "*ApiAccessLogGroup*";
     public static final int HEIGHT = 6;

--- a/dashboard/src/test/java/no/sikt/nva/monitoring/UpdateDashboardHandlerTest.java
+++ b/dashboard/src/test/java/no/sikt/nva/monitoring/UpdateDashboardHandlerTest.java
@@ -1,11 +1,25 @@
 package no.sikt.nva.monitoring;
 
+import static no.sikt.nva.monitoring.LambdaWidget.ASYNC_EVENT_AGE;
+import static no.sikt.nva.monitoring.LambdaWidget.ERRORS;
+import static no.sikt.nva.monitoring.LambdaWidget.FUNCTION_NAME_LABEL;
+import static no.sikt.nva.monitoring.LambdaWidget.INVOCATIONS;
+import static no.sikt.nva.monitoring.LambdaWidget.MAXIMUM_STAT;
+import static no.sikt.nva.monitoring.LambdaWidget.METRIC;
+import static no.sikt.nva.monitoring.LambdaWidget.PERIOD_5_MINUTES;
+import static no.sikt.nva.monitoring.LambdaWidget.SEARCH_EXPRESSION_TEMPLATE;
+import static no.sikt.nva.monitoring.LambdaWidget.SUM_STAT;
+import static no.sikt.nva.monitoring.LambdaWidget.THROTTLES;
+import static no.sikt.nva.monitoring.LambdaWidget.TIME_SERIES;
 import static no.sikt.nva.monitoring.UpdateDashboardHandler.API_ERRORS_4XX_WIDGET_NAME;
 import static no.sikt.nva.monitoring.UpdateDashboardHandler.API_ERRORS_5XX_WIDGET_NAME;
 import static no.sikt.nva.monitoring.UpdateDashboardHandler.API_REQUEST_COUNT_WIDGET_NAME;
 import static no.sikt.nva.monitoring.model.factory.AlarmWidgetFactory.ALARM;
 import static no.sikt.nva.monitoring.model.factory.AlarmWidgetFactory.ALARMS;
+import static no.sikt.nva.monitoring.model.factory.AlarmWidgetFactory.ALARM_STATE;
 import static no.sikt.nva.monitoring.model.factory.AlarmWidgetFactory.STATE_UPDATED_TIMESTAMP;
+import static no.sikt.nva.monitoring.model.factory.DocumentationLinksWidget.MARKDOWN;
+import static no.sikt.nva.monitoring.model.factory.DocumentationLinksWidget.TEXT;
 import static no.sikt.nva.monitoring.model.factory.ApiGatewayWidgetFactory.API_NAME;
 import static no.sikt.nva.monitoring.model.factory.ApiGatewayWidgetFactory.AWS_API_GATEWAY;
 import static no.sikt.nva.monitoring.model.factory.ApiGatewayWidgetFactory.NOT_STACKED;
@@ -33,8 +47,11 @@ import java.util.List;
 import no.sikt.nva.monitoring.model.AlarmProperties;
 import no.sikt.nva.monitoring.model.CloudWatchWidget;
 import no.sikt.nva.monitoring.model.DashboardBody;
+import no.sikt.nva.monitoring.model.LambdaGraphProperties;
 import no.sikt.nva.monitoring.model.LogProperties;
 import no.sikt.nva.monitoring.model.MetricProperties;
+import no.sikt.nva.monitoring.model.MetricSearchExpression;
+import no.sikt.nva.monitoring.model.TextProperties;
 import no.sikt.nva.monitoring.utils.FakeApiGatewayClient;
 import no.sikt.nva.monitoring.utils.FakeCloudWatchClient;
 import no.sikt.nva.monitoring.utils.FakeCloudWatchClientThrowingException;
@@ -74,9 +91,12 @@ public class UpdateDashboardHandlerTest {
     private static final CloudFormationCustomResourceEvent EVENT = CloudFormationCustomResourceEvent.builder().build();
     private static final String EXPECTED_ALARM_WIDGET =
         new CloudWatchWidget<>(ALARM, new AlarmProperties(ALARMS, List.of(ALARM_ARN_1, ALARM_ARN_2),
-                                                          STATE_UPDATED_TIMESTAMP), IGNORED, IGNORED,
+                                                          STATE_UPDATED_TIMESTAMP, List.of(ALARM_STATE)), IGNORED,
+                               IGNORED,
                                IGNORED,
                                IGNORED).toJsonString();
+    private static final String EXPECTED_DOCUMENTATION_LINKS_WIDGET =
+        new CloudWatchWidget<>(TEXT, new TextProperties(MARKDOWN), IGNORED, IGNORED, IGNORED, IGNORED).toJsonString();
     private static final String EXPECTED_5XX_WIDGET =
         new CloudWatchWidget<>(TYPE, METRIC_PROPERTIES_5XX, IGNORED, IGNORED, IGNORED, IGNORED).toJsonString();
     private static final String EXPECTED_4XX_WIDGET =
@@ -86,8 +106,8 @@ public class UpdateDashboardHandlerTest {
     public static final String EXPECTED_LOG_QUERY =
         "SOURCE 'master-pipelines-testLogGroup-ApiAccessLogGroup' "
         + "| filter @message like /\"status\"\\s*:\\s*\"5\\d{2}\"/ "
-        + "| fields httpMethod, path, status, error.message "
-        + "| stats count() as ErrorCount by httpMethod, path, status, error.message "
+        + "| fields httpMethod, path, status "
+        + "| stats count() as ErrorCount by httpMethod, path, status "
         + "| sort ErrorCount desc "
         + "| limit 100";
     public static final String LAMBDA_WIDGET_JSON = "lambda_widget.json";
@@ -188,6 +208,35 @@ public class UpdateDashboardHandlerTest {
         var expectedLambdaWidget = JsonUtils.dtoObjectMapper.readValue(EXPECTED_LAMBDA_WIDGET, CloudWatchWidget.class);
 
         assertThat(dashboardBody.widgets(), hasItem(expectedLambdaWidget));
+    }
+
+    @Test
+    void shouldUpdateDashboardWithDocumentationLinks() throws JsonProcessingException {
+        handler.handleRequest(EVENT, mockContext);
+        var dashboardBody = getDashboardBody();
+        var expectedWidget = JsonUtils.dtoObjectMapper.readValue(EXPECTED_DOCUMENTATION_LINKS_WIDGET,
+                                                                 CloudWatchWidget.class);
+        assertThat(dashboardBody.widgets(), hasItem(expectedWidget));
+    }
+
+    @Test
+    void shouldUpdateDashboardWithPerFunctionLambdaGraphs() throws JsonProcessingException {
+        handler.handleRequest(EVENT, mockContext);
+        var dashboardBody = getDashboardBody();
+        assertThat(dashboardBody.widgets(), hasItem(expectedPerFunctionGraph(ERRORS, SUM_STAT)));
+        assertThat(dashboardBody.widgets(), hasItem(expectedPerFunctionGraph(THROTTLES, SUM_STAT)));
+        assertThat(dashboardBody.widgets(), hasItem(expectedPerFunctionGraph(INVOCATIONS, SUM_STAT)));
+        assertThat(dashboardBody.widgets(), hasItem(expectedPerFunctionGraph(ASYNC_EVENT_AGE, MAXIMUM_STAT)));
+    }
+
+    private static CloudWatchWidget expectedPerFunctionGraph(String metricName, String stat)
+        throws JsonProcessingException {
+        var expression = SEARCH_EXPRESSION_TEMPLATE.formatted(metricName, stat, PERIOD_5_MINUTES);
+        List<List<Object>> metrics = List.of(List.of(new MetricSearchExpression(expression, FUNCTION_NAME_LABEL)));
+        var properties = new LambdaGraphProperties(metrics, metricName, TIME_SERIES, REGION, stat, PERIOD_5_MINUTES,
+                                                   true);
+        var widget = new CloudWatchWidget<>(METRIC, properties, IGNORED, IGNORED, IGNORED, IGNORED).toJsonString();
+        return JsonUtils.dtoObjectMapper.readValue(widget, CloudWatchWidget.class);
     }
 
     private static List<String> getAlarmArns(DashboardBody dashboardBody) {

--- a/dashboard/src/test/resources/lambda_widget.json
+++ b/dashboard/src/test/resources/lambda_widget.json
@@ -1,8 +1,8 @@
 {
-  "height": 4,
-  "width": 10,
-  "y": 4,
-  "x": 0,
+  "height": 3,
+  "width": 12,
+  "y": 0,
+  "x": 6,
   "type": "metric",
   "properties": {
     "metrics": [

--- a/dashboard/src/test/resources/lambda_widget.json
+++ b/dashboard/src/test/resources/lambda_widget.json
@@ -1,8 +1,8 @@
 {
   "height": 4,
-  "width": 24,
-  "y": 0,
-  "x": 5,
+  "width": 10,
+  "y": 4,
+  "x": 0,
   "type": "metric",
   "properties": {
     "metrics": [
@@ -10,21 +10,24 @@
         "AWS/Lambda",
         "Errors",
         {
-          "region": "eu-west-1"
+          "region": "eu-west-1",
+          "visible": false
         }
       ],
       [
         "AWS/Lambda",
         "Throttles",
         {
-          "region": "eu-west-1"
+          "region": "eu-west-1",
+          "visible": false
         }
       ],
       [
         "AWS/Lambda",
         "Invocations",
         {
-          "region": "eu-west-1"
+          "region": "eu-west-1",
+          "visible": false
         }
       ],
       [
@@ -48,7 +51,8 @@
         "AsyncEventAge",
         {
           "stat": "Maximum",
-          "region": "eu-west-1"
+          "region": "eu-west-1",
+          "visible": false
         }
       ]
     ],


### PR DESCRIPTION
Dashboard-justeringer (enkle endringer fra ønskelisten).

- Legger til dokumentlenker øverst (Instructions, Incident response, Redrive DLQ)
- Filtrerer alarm-widgeten til kun å vise `ALARM`-tilstand via `states`-property
- Splitter Lambda-metrikker: konto-nivå concurrency som `singleValue`-sparkline, og per-funksjon Errors/Throttles/Invocations/AsyncEventAge som `timeSeries`-grafer (CloudWatch `SEARCH`)
- Fjerner `error.message`-kolonnen fra API Gateway logg-tabellene
- Plasserer widgetene på et 24-kolonners rutenett: toppraden med alarmer/concurrency/lenker, Lambda-grafrad, API Gateway-rad, og 5XX/4XX logg-tabeller side ved side

https://sikt.atlassian.net/browse/NP-51227

<img width="3183" height="1255" alt="image" src="https://github.com/user-attachments/assets/87dee004-bfad-4413-9730-390aa867cdba" />

